### PR TITLE
next/image와 관련된 deprecated 설정을 업데이트 합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+certificates

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,27 @@
-import { withNextVideo } from "next-video/process";
+import { withNextVideo } from 'next-video/process';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['i.ytimg.com', 'gamemuncheol-s3.s3.ap-southeast-2.amazonaws.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'i.ytimg.com',
+        port: '',
+        pathname: '**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'gamemuncheol-s3.s3.ap-southeast-2.amazonaws.com',
+        port: '',
+        pathname: '**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+        port: '',
+        pathname: '**',
+      },
+    ],
   },
 };
 


### PR DESCRIPTION
### [관련 issue #]
#32 

### [리뷰 시 중점을 둘 곳]
- `next.config.mjs` 파일 내 설정을 [공식 문서 제안법](https://nextjs.org/docs/messages/next-image-unconfigured-host)으로 수정하였습니다.
- `.gitignore`에 항목을 하나 추가했습니다.
  - certificates 이라는 Next.js experimental feature 관련 항목

### [참고 사항(동작 화면 등)]
<img width="781" alt="image" src="https://github.com/gamemuncheol/gamemuncheol-frontend/assets/50035753/8c295bb9-ff3f-4a7c-b087-706b7785af0f">
앞으로 터미널에서 해당 warning이 보이지 않습니다.