### PR TITLE
로그인하지 않을 때도 userinfo api를 호출하는 문제 해결

### DIFF
--- a/src/services/queries/member.ts
+++ b/src/services/queries/member.ts
@@ -4,6 +4,7 @@ import api from '@/services/api';
 import { useQuery } from '@tanstack/react-query';
 import { memberKeys } from '../queryKeys';
 import { UserInfoType } from '@/types/member-type';
+import { useLoginStore } from '@/store/useMemberStore';
 
 const memberService = {
   getCheckNickname: async (name: string) => {
@@ -25,9 +26,10 @@ const memberQueryOptions = {
     enabled: isEnabled,
   }),
 
-  userInfo: () => ({
+  userInfo: (isLoggined: boolean) => ({
     queryKey: memberKeys.userinfo(),
     queryFn: () => memberService.getUserInfo(),
+    enabled: isLoggined,
   }),
 };
 
@@ -35,6 +37,7 @@ export function useNameCheck(name: string, isEnabled: boolean) {
   return useQuery(memberQueryOptions.checkNickname(name, isEnabled));
 }
 
-export function useUserInfo() {
-  return useQuery<UserInfoType>(memberQueryOptions.userInfo());
-}
+export const useUserInfo = () => {
+  const isLoggined = useLoginStore((state) => state.isLoggined);
+  return useQuery<UserInfoType>(memberQueryOptions.userInfo(isLoggined));
+};


### PR DESCRIPTION
### [관련 issue #]
#53 

### [리뷰 시 중점을 둘 곳]
`'/api/members/me'`를 호출할 때, enabled 속성을 전역변수 isLoggined 값으로 지정하였습니다.

### [참고 사항(동작 화면 등)]
아래 이미지에 나오는 에러들을 해결하였습니다. 
- 원인 : accessToken이 없는데, 계속 호출

![image](https://github.com/user-attachments/assets/345042b7-849a-4e77-b961-d1758bdd8117)

